### PR TITLE
Adds more info about Levers and Knobs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,92 @@
-knobby
-======
+# knobby
 
-Provides SDK for using feature flags and knobs
+Provides SDK for using feature flags.
 
-Basic Usage
+## Flag Types
+
+### Levers
+
+A flag that passes its test if it's turned on.
 
 ```php
+include('./vendor/autoload.php');
+
+$config = array(
+    array(
+        'name' => 'exampleOn',
+        'on' => true,
+        'type' => 'lever',
+    ),
+    array(
+        'name' => 'exampleOff',
+        'on' => false,
+        'type' => 'lever',
+    ),
+);
+
+$knobby = new \DDM\Knobby\Knobby($config);
+
+if ($knobby->test('exampleOn')) {
+    /*
+    feature code here will run as the lever is on
+    */
+}
+
+if ($knobby->test('exampleOff')) {
+    /*
+    feature code here will not run as the lever is off
+    */
+}
+```
+
+### Knobs
+
+A flag that passes its test if a test value is below the knob's value.
+
+```php
+include('./vendor/autoload.php');
+
 $config = array(
     array(
         'name' => 'testKnob',
         'type' => 'knob',
-        'min' => 10,
-        'max' => 50,
-        'value' => 15,    
+        'value' => 15,
     ),
-    array(
-        'name' => 'testLever',
-        'on' => false,
-        'type' => 'lever',
-    ),
-)};
+);
+
 $knobby = new \DDM\Knobby\Knobby($config);
 
-if($knobby->test('testLever')){
-	/*
-	feature code here will run
-	 */
-}
-
 $userValue = 20;
-if($knobby->test('testKnob',$userValue)){
-	/*
-	feature code here will not run, since the
-	user value is greater than the allowed threshold
-	 */
+if ($knobby->test('testKnob', $userValue)) {
+    /*
+    feature code here will not run, since the
+    user value is greater than the allowed value
+    */
 }
+```
 
+Knobs can also be used to randomly generate a test value within a specified range
+and then test this random value against the knob's value.
 
-- DDM Team
+```php
+include('./vendor/autoload.php');
+
+$config = array(
+    array(
+        'name' => 'testKnob',
+        'type' => 'knob',
+        'min' => '10',
+        'max' => '50',
+        'value' => 15,
+    ),
+);
+
+$knobby = new \DDM\Knobby\Knobby($config);
+
+if ($knobby->test('testKnob')) {
+    /*
+    feature code here may or may not run depending on the value of the randomly
+    generated test value between 10 and 50.
+    */
+}
+```

--- a/tests/KnobTest.php
+++ b/tests/KnobTest.php
@@ -4,7 +4,7 @@ use DDM\Knobby\Knob as Knob;
 
 class KnobTest extends PHPUnit_Framework_TestCase
 {
- 
+
     public function testDefaultZero(){
         $options = array();
         $knob = new \DDM\Knobby\Knob($options);
@@ -15,7 +15,7 @@ class KnobTest extends PHPUnit_Framework_TestCase
     public function testMin(){
         $options = array(
             'min' => 10,
-            'max' => 100    
+            'max' => 100
         );
 
         $knob = new Knob($options);
@@ -28,7 +28,7 @@ class KnobTest extends PHPUnit_Framework_TestCase
     public function testMax(){
         $options = array(
             'min' => 10,
-            'max' => 100    
+            'max' => 100
         );
 
         $knob = new Knob($options);
@@ -40,7 +40,7 @@ class KnobTest extends PHPUnit_Framework_TestCase
     public function testMaxGreaterThanMin(){
        $options = array(
             'min' => 10,
-            'max' => 100    
+            'max' => 100
         );
 
         $knob = new Knob($options);
@@ -53,7 +53,7 @@ class KnobTest extends PHPUnit_Framework_TestCase
     public function testMinLessThanMax(){
        $options = array(
             'min' => 10,
-            'max' => 100    
+            'max' => 100
         );
 
         $knob = new Knob($options);
@@ -67,8 +67,7 @@ class KnobTest extends PHPUnit_Framework_TestCase
         $knob = new Knob();
         $knob['value'] = 30;
         $value = 40;
-        $expected = false;
-        $this->assertEquals($expected, $knob->test($value), 'Value greater than knob value should test false');
+        $this->assertFalse($knob->test($value), 'Value greater than knob value should test false');
     }
 
     public function testWithTrueRandomishValue(){
@@ -76,8 +75,7 @@ class KnobTest extends PHPUnit_Framework_TestCase
         $knob->shouldReceive('createRandomishValue')
              ->andReturn(20);
         $knob->setValue(30);
-        $expected = true;
-        $this->assertEquals($expected, $knob->test(), 'Randomish value less than knob value should test true');
+        $this->assertTrue($knob->test(), 'Randomish value less than knob value should test true');
     }
 
     public function testWithFalseRandomishValue(){
@@ -85,14 +83,13 @@ class KnobTest extends PHPUnit_Framework_TestCase
         $knob->shouldReceive('createRandomishValue')
              ->andReturn(40);
         $knob->setValue(30);
-        $expected = false;
-        $this->assertEquals($expected, $knob->test(), 'Randomish value greater than knob value should test false');
+        $this->assertFalse($knob->test(), 'Randomish value greater than knob value should test false');
     }
 
     public function testCreateRandomishValue(){
         $knob = new Knob();
         $value = $knob->createRandomishValue();
-        $this->assertTrue($value >= $knob['min'] && $value <= $knob['max']);        
+        $this->assertTrue($value >= $knob['min'] && $value <= $knob['max']);
     }
 
 }

--- a/tests/KnobbyTest.php
+++ b/tests/KnobbyTest.php
@@ -9,7 +9,7 @@ class KnobbyTest extends PHPUnit_Framework_TestCase
                 'type' => 'knob',
                 'min' => 10,
                 'max' => 50,
-                'value' => 15,    
+                'value' => 15,
             ),
             array(
                 'name' => 'testLever',
@@ -31,7 +31,7 @@ class KnobbyTest extends PHPUnit_Framework_TestCase
                 'type' => 'knob',
                 'min' => 10,
                 'max' => 50,
-                'value' => 15,    
+                'value' => 15,
             ),
             array(
                 'name' => 'testLever',
@@ -55,13 +55,13 @@ class KnobbyTest extends PHPUnit_Framework_TestCase
                 'min' => 10,
                 'max' => 50,
                 'value' => 15,
-                'dependsOn' => [],                
+                'dependsOn' => [],
             ),
             array(
                 'name' => 'testLever',
                 'on' => false,
                 'type' => 'lever',
-                'dependsOn' => [],    
+                'dependsOn' => [],
             ),
         );
         $knobby = new \DDM\Knobby\Knobby();
@@ -77,14 +77,14 @@ class KnobbyTest extends PHPUnit_Framework_TestCase
                 'type' => 'knob',
                 'min' => 10,
                 'max' => 50,
-                'value' => 15,    
-                'dependsOn' => [],    
+                'value' => 15,
+                'dependsOn' => [],
             ),
             array(
                 'name' => 'testLever',
                 'on' => false,
                 'type' => 'lever',
-                'dependsOn' => [],    
+                'dependsOn' => [],
             ),
         ));
         $knobby = new \DDM\Knobby\Knobby();
@@ -108,15 +108,14 @@ class KnobbyTest extends PHPUnit_Framework_TestCase
                 'type' => 'knob',
                 'min' => 10,
                 'max' => 50,
-                'value' => 15,    
+                'value' => 15,
             ),
         );
         $knobby = new \DDM\Knobby\Knobby();
         $knobby->loadConfigArray($config);
 
         $actual = $knobby->test('testKnob', 13);
-        $expected = true;
-        $this->assertEquals($expected, $actual, 'knob should work');
+        $this->assertTrue($actual, 'knob should work');
     }
 
     public function testLeverParentOn(){
@@ -138,8 +137,7 @@ class KnobbyTest extends PHPUnit_Framework_TestCase
         $knobby->loadConfigArray($config);
 
         $actual = $knobby->test('testChildLever');
-        $expected = true;
-        $this->assertEquals($expected, $actual, 'lever should work since parent and child are both true');
+        $this->assertTrue($actual, 'lever should work since parent and child are both true');
     }
 
     public function testLeverParentOff(){
@@ -161,10 +159,9 @@ class KnobbyTest extends PHPUnit_Framework_TestCase
         $knobby->loadConfigArray($config);
 
         $actual = $knobby->test('testChildLever');
-        $expected = false;
-        $this->assertEquals($expected, $actual, 'lever should not work since parent is false');
+        $this->assertFalse($actual, 'lever should not work since parent is false');
     }
-    
+
     public function testLeverGrandParentOff(){
         $config = array(
             array(
@@ -190,8 +187,7 @@ class KnobbyTest extends PHPUnit_Framework_TestCase
         $knobby->loadConfigArray($config);
 
         $actual = $knobby->test('testChildLever');
-        $expected = false;
-        $this->assertEquals($expected, $actual, 'lever should not work since grandparent is false');
+        $this->assertFalse($actual, 'lever should not work since grandparent is false');
     }
 
     public function testLeverParentOffGrandParentOn(){
@@ -219,9 +215,8 @@ class KnobbyTest extends PHPUnit_Framework_TestCase
         $knobby->loadConfigArray($config);
 
         $actual = $knobby->test('testChildLever');
-        $expected = false;
-        $this->assertEquals($expected, $actual, 'lever should not work since parent is false');
-    }    
+        $this->assertFalse($actual, 'lever should not work since parent is false');
+    }
 
     public function testLeverParentOnGrandParentOn(){
         $config = array(
@@ -248,8 +243,7 @@ class KnobbyTest extends PHPUnit_Framework_TestCase
         $knobby->loadConfigArray($config);
 
         $actual = $knobby->test('testChildLever');
-        $expected = true;
-        $this->assertEquals($expected, $actual, 'lever should work since grandparent and parent are true');
-    }    
+        $this->assertTrue($actual, 'lever should work since grandparent and parent are true');
+    }
 
 }

--- a/tests/LeverTest.php
+++ b/tests/LeverTest.php
@@ -5,8 +5,7 @@ class LeverTest extends PHPUnit_Framework_TestCase
     public function testDefaultOn(){
         $options = array();
         $lever = new \DDM\Knobby\Lever($options);
-        $expected = true;
-        $this->assertEquals($expected, $lever->test(), 'Lever should default to on');
+        $this->assertTrue($lever->test(), 'Lever should default to on');
     }
 
     public function testSetOff(){
@@ -14,7 +13,6 @@ class LeverTest extends PHPUnit_Framework_TestCase
             'on' => false
         );
         $lever = new \DDM\Knobby\Lever($options);
-        $expected = false;
-        $this->assertEquals($expected, $lever->test(), 'Lever should be false');
+        $this->assertFalse($lever->test(), 'Lever should be false');
     }
 }


### PR DESCRIPTION
Expands README.md with additional information on how levers and knobs
work.

Changes some asserts in the tests from assertEquals to assertTrue or
assertFalse to make the tests easier to read.
