### PR TITLE
Adds Gate Flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ $knobby = new \DDM\Knobby\Knobby($config);
 $userValue = 20;
 if ($knobby->test('testKnob', $userValue)) {
     /*
-    feature code here will not run, since the
-    user value is greater than the allowed value
+    feature code here will not run, since the user value is greater than the
+    allowed value
     */
 }
 ```
@@ -87,6 +87,60 @@ if ($knobby->test('testKnob')) {
     /*
     feature code here may or may not run depending on the value of the randomly
     generated test value between 10 and 50.
+    */
+}
+```
+
+### Gates
+
+A flag that always passes its test if it is unlocked. If the gate is locked, the
+flag's test only passes if supplied test value is true.
+
+```php
+include('./vendor/autoload.php');
+
+$config = array(
+    array(
+        'name' => 'lockedGate',
+        'type' => 'gate',
+        'locked' => true
+    ),
+    array(
+        'name' => 'unlockedGate',
+        'type' => 'gate',
+        'locked' => false
+    ),
+);
+
+$knobby = new \DDM\Knobby\Knobby($config);
+$isUserAdmin = false;
+
+if ($knobby->test('lockedGate', $isUserAdmin)) {
+    /*
+    feature code here will not run, since the test value is false
+    */
+}
+
+if ($knobby->test('unlockedGate', $isUserAdmin)) {
+    /*
+    feature code here will run regardless of the test value because the gate is
+    unlocked
+    */
+}
+
+$isUserAdmin = true;
+
+if ($knobby->test('lockedGate', $isUserAdmin)) {
+    /*
+    feature code here will run even though the gate is locked since the test value
+    is true
+    */
+}
+
+if ($knobby->test('unlockedGate', $isUserAdmin)) {
+    /*
+    feature code here will run regardless of the test value because the gate is
+    unlocked
     */
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "license": "MIT",
     "autoload": {
         "psr-4": {
-            "DDM\\Knobby\\": "src/"
+            "DDM\\Knobby\\": "src/",
+            "DDM\\Knobby\\Tests\\": "tests/"
         }
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -3,7 +3,7 @@
         "This file locks the dependencies of your project to a known state",
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
     ],
-    "hash": "68c173504b2c9758afffc1bc0f5e9690",
+    "hash": "5bcbccb3764f6c8ce3d26daac3c102c9",
     "packages": [
 
     ],

--- a/src/Gate.php
+++ b/src/Gate.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace DDM\Knobby;
+
+class Gate extends Flag
+{
+    protected $data = [
+        'locked' => false,
+        'dependsOn' => [],
+    ];
+
+    public function test($value = false){
+        if(!$this['locked']){
+            return true;
+        }
+
+        return (bool) $value;
+    }
+
+    public function setLocked($locked){
+        $this->data['locked'] = (bool) $locked;
+    }
+}

--- a/tests/GateTest.php
+++ b/tests/GateTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace DDM\Knobby\Tests;
+
+use DDM\Knobby\Gate;
+
+class GateTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDefaultUnlocked(){
+        $options = array();
+        $gate = new Gate($options);
+        $this->assertTrue($gate->test(), 'Gate should default to unlocked');
+    }
+
+    public function testLockedGateWithoutKey(){
+        $gate = new Gate(['locked' => true]);
+        $this->assertFalse($gate->test(), 'Gate should be locked and fail with no key provided.');
+    }
+
+    public function testLockedGateWithKey(){
+        $gate = new Gate(['locked' => true]);
+        $this->assertTrue($gate->test(true), 'Locked gate should allow passage if key is provided.');
+    }
+
+    public function testUnlockedGateWithoutKey(){
+        $gate = new Gate(['locked' => false]);
+        $this->assertTrue($gate->test(), 'Unlocked gate should allow passage even in the absence of the key.');
+    }
+
+    public function testUnlockedGateWithKey(){
+        $gate = new Gate(['locked' => false]);
+        $this->assertTrue($gate->test(true), 'Unlocked gate should allow passage with the key.');
+    }
+}

--- a/tests/KnobTest.php
+++ b/tests/KnobTest.php
@@ -1,8 +1,10 @@
 <?php
 
+namespace DDM\Knobby\Tests;
+
 use DDM\Knobby\Knob as Knob;
 
-class KnobTest extends PHPUnit_Framework_TestCase
+class KnobTest extends \PHPUnit_Framework_TestCase
 {
 
     public function testDefaultZero(){

--- a/tests/KnobbyTest.php
+++ b/tests/KnobbyTest.php
@@ -1,6 +1,8 @@
 <?php
 
-class KnobbyTest extends PHPUnit_Framework_TestCase
+namespace DDM\Knobby\Tests;
+
+class KnobbyTest extends \PHPUnit_Framework_TestCase
 {
     public function testLoadConfigArray(){
         $config = array(

--- a/tests/LeverTest.php
+++ b/tests/LeverTest.php
@@ -1,6 +1,8 @@
 <?php
 
-class LeverTest extends PHPUnit_Framework_TestCase
+namespace DDM\Knobby\Tests;
+
+class LeverTest extends \PHPUnit_Framework_TestCase
 {
     public function testDefaultOn(){
         $options = array();


### PR DESCRIPTION
Adds the concept of gate flags. Gates work almost like levers in which
they are either locked or unlocked. When a gate is tested, an optional
argument is passed to the test method. If the gate is locked, the test
will return a boolean value of the passed in argument. If the gate is
unlocked, the test will always return true.

One prossible use of the gate flag is to lock down permissions to only
users with a specific permission while the feature is being tested and
then to open it up to the general public by unlocking the gate.

Adds related unit tests and documentation.
