### PR TITLE
Update Readme to match the constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ $config = array(
     ),
 );
 
-$knobby = new \DDM\Knobby\Knobby($config);
+$knobby = new \DDM\Knobby\Knobby();
+$knobby->loadConfigArray($config);
 
 if ($knobby->test('exampleOn')) {
     /*


### PR DESCRIPTION
Docs didn't agree with the code. The constructor can't take a config array.